### PR TITLE
chore: move AWS settings to GH actions secrets and variables

### DIFF
--- a/.github/actions/oidc/action.yaml
+++ b/.github/actions/oidc/action.yaml
@@ -1,6 +1,17 @@
 ---
 name: AWS OIDC Credentials via Role Assume Chaining
 description: Retrieve AWS credentials by chaining role assumes
+inputs:
+  role-for-oidc:
+    description: The role that should be used for GitHub OIDC authentication
+    required: true
+  role-to-assume:
+    description: The role that should be finally assumed
+    required: true
+  aws-region:
+    description: The AWS region
+    required: false
+    default: us-east-1
 
 runs:
   using: composite
@@ -8,8 +19,8 @@ runs:
     - name: assume oidc role
       uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722  # v4.1.0
       with:
-        aws-region: us-east-1
-        role-to-assume: "arn:aws:iam::997179694723:role/github-actions-research-account-oidc-role"
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-for-oidc }}
         role-session-name: "oz-mcp"
         role-duration-seconds: 900
     - name: assume target role
@@ -19,8 +30,8 @@ runs:
         aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
         aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
-        aws-region: us-east-1
+        aws-region: ${{ inputs.aws-region }}
         role-chaining: true
-        role-to-assume: "arn:aws:iam::301065321042:role/GithubOIDCResearchAccountRole"
+        role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: "oz-mcp"
         role-duration-seconds: 900

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,9 @@ jobs:
       contents: read
       packages: write
     env:
-     REGISTRY: 301065321042.dkr.ecr.us-east-1.amazonaws.com
+      REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      ROLE_FOR_OIDC: "${{ secrets.ROLE_FOR_OIDC }}"
+      ROLE_TO_ASSUME: "${{ secrets.ROLE_TO_ASSUME }}"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -37,6 +39,9 @@ jobs:
 
       - name: Set up AWS credentials via OIDC and role chaining
         uses: ./.github/actions/oidc
+        with:
+          role-for-oidc: ${{ env.ROLE_FOR_OIDC }}
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
@@ -59,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     env:
-      ROLE_FOR_OIDC: "arn:aws:iam::997179694723:role/github-actions-research-account-oidc-role"
-      ROLE_TO_ASSUME: "arn:aws:iam::301065321042:role/GithubOIDCResearchAccountRole"
-      ECS_CLUSTER: "mcp-prod-cluster"
-      ECS_SERVICE: "mcp-prod-service"
-      AWS_REGION: "us-east-1"
+      ROLE_FOR_OIDC: "${{ secrets.ROLE_FOR_OIDC }}"
+      ROLE_TO_ASSUME: "${{ secrets.ROLE_TO_ASSUME }}"
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
     permissions:
       contents: read
       id-token: write
@@ -73,6 +78,9 @@ jobs:
 
       - name: Set up AWS credentials via OIDC and role chaining
         uses: ./.github/actions/oidc
+        with:
+          role-for-oidc: ${{ env.ROLE_FOR_OIDC }}
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
       
       - name: AWS ECS force new deployment
         run: |


### PR DESCRIPTION
Moves some of the AWS settings to secrets and variables. We don't want to expose settings like account ID, role names etc.