### PR TITLE
Use stable TS API from Contract MCP package

### DIFF
--- a/app/contracts/cairo/[transport]/route.ts
+++ b/app/contracts/cairo/[transport]/route.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler } from "mcp-handler";
-import { registerCairoTools } from "@openzeppelin/contracts-mcp/src/cairo/tools";
+import { registerCairoTools } from "@openzeppelin/contracts-mcp";
 import { getTitleText } from "@/contracts/prompts";
 import { getInstructionsText } from "@/contracts/prompts";
 import contractsMcpPackage from "@openzeppelin/contracts-mcp/package.json";

--- a/app/contracts/solidity/[transport]/route.ts
+++ b/app/contracts/solidity/[transport]/route.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler } from "mcp-handler";
-import { registerSolidityTools } from "@openzeppelin/contracts-mcp/src/solidity/tools";
+import { registerSolidityTools } from "@openzeppelin/contracts-mcp";
 import { getTitleText } from "@/contracts/prompts";
 import { getInstructionsText } from "@/contracts/prompts";
 import contractsMcpPackage from "@openzeppelin/contracts-mcp/package.json";

--- a/app/contracts/stellar/[transport]/route.ts
+++ b/app/contracts/stellar/[transport]/route.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler } from "mcp-handler";
-import { registerStellarTools } from "@openzeppelin/contracts-mcp/src/stellar/tools";
+import { registerStellarTools } from "@openzeppelin/contracts-mcp";
 import { getTitleText } from "@/contracts/prompts";
 import { getInstructionsText } from "@/contracts/prompts";
 import contractsMcpPackage from "@openzeppelin/contracts-mcp/package.json";

--- a/app/contracts/stylus/[transport]/route.ts
+++ b/app/contracts/stylus/[transport]/route.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler } from "mcp-handler";
-import { registerStylusTools } from "@openzeppelin/contracts-mcp/src/stylus/tools";
+import { registerStylusTools } from "@openzeppelin/contracts-mcp";
 import { getTitleText } from "@/contracts/prompts";
 import { getInstructionsText } from "@/contracts/prompts";
 import contractsMcpPackage from "@openzeppelin/contracts-mcp/package.json";

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "dependencies": {
         "@next/third-parties": "^15.4.4",
-        "@openzeppelin/contracts-mcp": "^0.0.5",
+        "@openzeppelin/contracts-mcp": "^0.1.0",
         "mcp-handler": "^1.0.1",
         "next": "^15.3.3",
         "react": "^19.1.0",
@@ -223,13 +223,13 @@
 
     "@next/third-parties": ["@next/third-parties@15.4.4", "", { "dependencies": { "third-party-capital": "1.0.20" }, "peerDependencies": { "next": "^13.0.0 || ^14.0.0 || ^15.0.0", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0" } }, "sha512-0GIEDSxfl9hTU4Ne1TVr/lZUS1wGhDPB4gt6TNvLBA3Fioum+qZRoPt3fiOW9hHQynyLsojglRDaB97T92h0Og=="],
 
-    "@openzeppelin/contracts-mcp": ["@openzeppelin/contracts-mcp@0.0.5", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.11.1", "@openzeppelin/wizard": "^0.6.0", "@openzeppelin/wizard-cairo": "^2.0.0", "@openzeppelin/wizard-common": "^0.0.2", "@openzeppelin/wizard-stellar": "^0.4.1", "@openzeppelin/wizard-stylus": "^0.2.0-alpha.5" }, "bin": { "contracts-mcp": "dist/index.js" } }, "sha512-/y6Y2l0BLrlQ3KnaDVc8PjFem0O4fg+Nhp+mUBIGbZKxOmXJ88o67dExFFgfEjALRO+zdmqmmVp8/WQ9PyNZdA=="],
+    "@openzeppelin/contracts-mcp": ["@openzeppelin/contracts-mcp@0.1.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.11.1", "@openzeppelin/wizard": "^0.7.1", "@openzeppelin/wizard-cairo": "^2.0.0", "@openzeppelin/wizard-common": "^0.1.0", "@openzeppelin/wizard-stellar": "^0.4.2", "@openzeppelin/wizard-stylus": "^0.2.0" }, "bin": { "contracts-mcp": "dist/cli.js" } }, "sha512-2dfbBMLMuz/1KJe6DA//cR+PdiG24008LkgLg3xXQS9ssG14SnxEqIBenX0sCsR/XCObXvKQLyJ//OszUD9QgA=="],
 
-    "@openzeppelin/wizard": ["@openzeppelin/wizard@0.6.0", "", {}, "sha512-IGBvvUW0DQs+8uaArERmUqAJYUNPE8CJw08cuXt+v9NSJfqR+R2ik1vAjyKlT7mTYhofOMZolqlm9vIYfxiDbQ=="],
+    "@openzeppelin/wizard": ["@openzeppelin/wizard@0.7.1", "", {}, "sha512-aRtWWF67YuTtuOzkMEuMXIObOxa4bQZWTtU2n6zy7pTNkpuSuYsH7GT4U7U0fbFAN3ELkpNfJLmEf3oBeWO21A=="],
 
     "@openzeppelin/wizard-cairo": ["@openzeppelin/wizard-cairo@2.0.0", "", {}, "sha512-rPfJp9Wbex5x9f+P7uJI3kBFqG2SexGt7csLGExnRNWMu8T9t0sFDHVQzaaskrJErqoWYMcGkIsiNHqXDUIzWQ=="],
 
-    "@openzeppelin/wizard-common": ["@openzeppelin/wizard-common@0.0.2", "", {}, "sha512-JFEzCdORjaTRN0aEgAJavz59F+Z0GyIr+yHDvmqByiaSN8OUJwNw/OUNrIWM27gfgovVXpgw1AH883VxtWifkg=="],
+    "@openzeppelin/wizard-common": ["@openzeppelin/wizard-common@0.1.0", "", {}, "sha512-tpqxQKQ4RVliYU7CQrKUtGS984kyAek1Tv3YyJsA21+bQeMRqfQ87U3sWAQuteuaTUkxfvMD5sux6pG99Qy5xg=="],
 
     "@openzeppelin/wizard-stellar": ["@openzeppelin/wizard-stellar@0.4.2", "", {}, "sha512-8t1Swea7dvC1lCPb1YvFF9AqroqQJ47QBpLpMxevaoLi5avNMbKln2hkGCNittkGgUReaS2i4TbYjxkjHIJOyA=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next/third-parties": "^15.4.4",
-    "@openzeppelin/contracts-mcp": "^0.0.5",
+    "@openzeppelin/contracts-mcp": "^0.1.0",
     "mcp-handler": "^1.0.1",
     "next": "^15.3.3",
     "react": "^19.1.0",


### PR DESCRIPTION
Updates dependency to `@openzeppelin/contracts-mcp` 0.1.0, where we added the `register<Language>Tools` functions to the stable API so that they can be imported without relying on source file paths.  This allows that package to follow semantic versioning for these functions.