### PR TITLE
ci: declare explicit GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
         default: 'minor'
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The product-security baseline rollout will set the repository default `GITHUB_TOKEN` permissions to **read-only** (with PR-approval by the token disabled). Workflows that rely on the current implicit write default would start failing at their next write operation. This PR makes each workflow's required permissions explicit so the downgrade is a no-op for this repo.

| Workflow | Declared permissions |
|---|---|
| `.github/workflows/release.yml` | `contents: write` |
| `.github/workflows/test.yml` | `contents: read` |

Scopes were inferred from the actions and commands each workflow uses; read-only workflows get `contents: read`. Draft on purpose — please review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)